### PR TITLE
geom_alt props

### DIFF
--- a/data/856/324/55/85632455.geojson
+++ b/data/856/324/55/85632455.geojson
@@ -833,7 +833,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -908,7 +907,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1582318521,
+    "wof:lastmodified":1583205166,
     "wof:name":"Tonga",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/324/55/85632455.geojson
+++ b/data/856/324/55/85632455.geojson
@@ -833,6 +833,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -887,6 +888,10 @@
     },
     "wof:country":"TO",
     "wof:country_alpha3":"TON",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"0a89e3ec3f09b7e5d7212c02698f5237",
     "wof:hierarchy":[
         {
@@ -903,7 +908,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1566581541,
+    "wof:lastmodified":1582318521,
     "wof:name":"Tonga",
     "wof:parent_id":102191583,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.