### PR TITLE
Name updates

### DIFF
--- a/data/856/324/55/85632455.geojson
+++ b/data/856/324/55/85632455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065749,
-    "geom:area_square_m":764384443.761038,
+    "geom:area_square_m":764384141.892778,
     "geom:bbox":"-176.219635,-22.342083,-173.700439,-15.560416",
     "geom:latitude":-19.842768,
     "geom:longitude":-174.817923,
@@ -52,6 +52,9 @@
     "name:arg_x_preferred":[
         "Tonga"
     ],
+    "name:ary_x_preferred":[
+        "\u0637\u0648\u0646\u063a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u062a\u0648\u0646\u062c\u0627"
     ],
@@ -68,6 +71,9 @@
         "\u0422\u043e\u043d\u0433\u0430"
     ],
     "name:bam_x_preferred":[
+        "Tonga"
+    ],
+    "name:ban_x_preferred":[
         "Tonga"
     ],
     "name:bcl_x_preferred":[
@@ -157,6 +163,9 @@
     "name:ell_x_preferred":[
         "\u03a4\u03cc\u03bd\u03b3\u03ba\u03b1"
     ],
+    "name:eng_gb_x_preferred":[
+        "Tonga"
+    ],
     "name:eng_x_preferred":[
         "Tonga"
     ],
@@ -220,6 +229,9 @@
         "Tonngaa"
     ],
     "name:gag_x_preferred":[
+        "Tonga"
+    ],
+    "name:gcr_x_preferred":[
         "Tonga"
     ],
     "name:ger_x_colloquial":[
@@ -610,6 +622,9 @@
     "name:sqi_x_preferred":[
         "Tonga"
     ],
+    "name:srd_x_preferred":[
+        "Tonga"
+    ],
     "name:srp_x_preferred":[
         "\u0422\u043e\u043d\u0433\u0430"
     ],
@@ -740,6 +755,9 @@
     ],
     "name:yue_x_preferred":[
         "\u6e6f\u52a0"
+    ],
+    "name:zea_x_preferred":[
+        "Tonga"
     ],
     "name:zha_x_preferred":[
         "Tonga"
@@ -908,7 +926,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1583797442,
+    "wof:lastmodified":1587428239,
     "wof:name":"Tonga",
     "wof:parent_id":102191583,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.