### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/114/190/941/1/1141909411.geojson
+++ b/data/114/190/941/1/1141909411.geojson
@@ -33,17 +33,32 @@
     "name:ara_x_preferred":[
         "\u0646\u0648\u0643\u0648 \u0623\u0644\u0648\u0641\u0627"
     ],
+    "name:ary_x_preferred":[
+        "\u0646\u0648\u0643\u0648 \u0623\u0644\u0648\u0641\u0627"
+    ],
     "name:ast_x_preferred":[
+        "Nuku'alofa"
+    ],
+    "name:avk_x_preferred":[
         "Nuku'alofa"
     ],
     "name:aze_x_preferred":[
         "Nukualofa"
     ],
+    "name:ban_x_preferred":[
+        "Nuku\u02bbalofa"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041d\u0443\u043a\u0443\u0430\u043b\u043e\u0444\u0430"
     ],
+    "name:bel_x_variant":[
+        "\u041d\u0443\u043a\u0443\u0430\u043b\u043e\u0444\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09c1\u0995\u09c1\u09af\u09bc\u09be\u09b2\u09cb\u09ab\u09be"
+    ],
+    "name:ben_x_variant":[
+        "\u09a8\u09c1\u0995\u09c1'\u0986\u09b2\u09cb\u09ab\u09be"
     ],
     "name:bod_x_preferred":[
         "\u0f53\u0f74\u0f0b\u0f41\u0f74\u0f0b\u0f68\u0f0b\u0f63\u0f7c\u0f0b\u0f67\u0fa5\u0f0d"
@@ -111,6 +126,9 @@
     "name:fin_x_variant":[
         "Nuku\u02bbalofa"
     ],
+    "name:fit_x_preferred":[
+        "Nuku\u02bbalofa"
+    ],
     "name:fra_x_preferred":[
         "Nuku'alofa"
     ],
@@ -121,6 +139,9 @@
         "Nuku'alofa"
     ],
     "name:gla_x_preferred":[
+        "Nuku'alofa"
+    ],
+    "name:gle_x_preferred":[
         "Nuku'alofa"
     ],
     "name:glg_x_preferred":[
@@ -210,6 +231,9 @@
     "name:ltz_x_preferred":[
         "Nuku'alofa"
     ],
+    "name:mal_x_preferred":[
+        "\u0d28\u0d41\u0d15\u0d4d\u0d15\u0d41\u0d35\u0d3e\u0d32\u0d4b\u0d2b"
+    ],
     "name:mar_x_preferred":[
         "\u0928\u0941\u0915\u0941-\u0905\u0932\u094b\u092b\u093e"
     ],
@@ -219,6 +243,9 @@
     "name:mon_x_preferred":[
         "\u041d\u0443\u043a\u0443\u0430\u043b\u043e\u0444\u0430"
     ],
+    "name:mri_x_preferred":[
+        "Nukuaroha"
+    ],
     "name:mrj_x_preferred":[
         "\u041d\u0443\u043a\u0443\u0430\u043b\u043e\u0444\u0430"
     ],
@@ -227,6 +254,9 @@
     ],
     "name:mzn_x_preferred":[
         "\u0646\u0648\u06a9\u0648\u0622\u0644\u0648\u0641\u0627"
+    ],
+    "name:nah_x_preferred":[
+        "Nukualofa"
     ],
     "name:nan_x_preferred":[
         "Nuku'alofa"
@@ -255,6 +285,9 @@
     "name:pms_x_preferred":[
         "Nuku'alofa"
     ],
+    "name:pnb_x_preferred":[
+        "\u0646\u0648\u06a9\u0648 \u0627\u0644\u0648\u0641\u0627"
+    ],
     "name:pol_x_preferred":[
         "Nuku'alofa"
     ],
@@ -263,6 +296,9 @@
     ],
     "name:por_x_preferred":[
         "Nuku'alofa"
+    ],
+    "name:pus_x_preferred":[
+        "\u0646\u0648\u06a9\u0648\u0627\u0644\u0648\u0641\u0627"
     ],
     "name:ron_x_preferred":[
         "Nuku'alofa"
@@ -288,6 +324,15 @@
     "name:sme_x_preferred":[
         "Nuku'alofa"
     ],
+    "name:sme_x_variant":[
+        "Nuku\u02bbalofa"
+    ],
+    "name:smn_x_preferred":[
+        "Nuku\u02bbalofa"
+    ],
+    "name:sms_x_preferred":[
+        "Nuku\u02bbalofa"
+    ],
     "name:sna_x_preferred":[
         "Nuku\u02bbalofa"
     ],
@@ -298,6 +343,9 @@
         "Nukualofa"
     ],
     "name:sqi_x_preferred":[
+        "Nuku'alofa"
+    ],
+    "name:srd_x_preferred":[
         "Nuku'alofa"
     ],
     "name:srp_x_preferred":[
@@ -317,6 +365,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c28\u0c41\u0c15\u0c41\u0c35\u0c3e\u0c32\u0c4b\u0c2b\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u041d\u0443\u043a\u0443\u0430\u043b\u043e\u0444\u0430"
     ],
     "name:tgl_x_preferred":[
         "Nukualofa"
@@ -359,6 +410,12 @@
     ],
     "name:war_x_preferred":[
         "Nuku\u02bbalofa"
+    ],
+    "name:wuu_x_preferred":[
+        "\u52aa\u5e93\u963f\u6d1b\u6cd5"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dc\u10e3\u10d9\u10e3\u10d0\u10da\u10dd\u10e4\u10d0"
     ],
     "name:yor_x_preferred":[
         "Nuku\u02bbalofa"
@@ -506,7 +563,7 @@
         }
     ],
     "wof:id":1141909411,
-    "wof:lastmodified":1607390901,
+    "wof:lastmodified":1690874883,
     "wof:name":"Nukualofa",
     "wof:parent_id":85679003,
     "wof:placetype":"locality",

--- a/data/421/204/409/421204409.geojson
+++ b/data/421/204/409/421204409.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0646\u064a\u0627\u0641\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u064a\u0627\u0641\u0648"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09c7\u0987\u09df\u09be\u09ab\u09c1"
     ],
@@ -257,7 +260,7 @@
         }
     ],
     "wof:id":421204409,
-    "wof:lastmodified":1636495629,
+    "wof:lastmodified":1690874882,
     "wof:name":"Neiafu",
     "wof:parent_id":85679007,
     "wof:placetype":"locality",

--- a/data/856/324/55/85632455.geojson
+++ b/data/856/324/55/85632455.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0422\u043e\u043d\u0433\u0430"
+    ],
     "name:ace_x_preferred":[
         "Tonga"
     ],
@@ -42,6 +45,15 @@
     ],
     "name:amh_x_preferred":[
         "\u1276\u1295\u130b"
+    ],
+    "name:ami_x_preferred":[
+        "Tonga"
+    ],
+    "name:ang_x_preferred":[
+        "Tonga"
+    ],
+    "name:anp_x_preferred":[
+        "\u091f\u094b\u0902\u0917\u093e"
     ],
     "name:ara_x_preferred":[
         "\u062a\u0648\u0646\u063a\u0627"
@@ -59,6 +71,9 @@
         "\u062a\u0648\u0646\u062c\u0627"
     ],
     "name:ast_x_preferred":[
+        "Tonga"
+    ],
+    "name:avk_x_preferred":[
         "Tonga"
     ],
     "name:azb_x_preferred":[
@@ -87,6 +102,9 @@
     ],
     "name:ben_x_preferred":[
         "\u099f\u09cb\u0999\u09cd\u0997\u09be"
+    ],
+    "name:bis_x_preferred":[
+        "Tonga"
     ],
     "name:bjn_x_preferred":[
         "Tonga"
@@ -124,6 +142,9 @@
     "name:che_x_preferred":[
         "\u0422\u043e\u043d\u0433\u0430"
     ],
+    "name:chr_x_preferred":[
+        "\u13d4\u13c2\u13aa"
+    ],
     "name:chu_x_preferred":[
         "\u0422\u043e\u043d\u0433\u0430"
     ],
@@ -135,6 +156,9 @@
     ],
     "name:cor_x_preferred":[
         "Tonga"
+    ],
+    "name:cos_x_preferred":[
+        "Tongu"
     ],
     "name:crh_x_preferred":[
         "Tonga"
@@ -228,6 +252,9 @@
     "name:ful_x_preferred":[
         "Tonngaa"
     ],
+    "name:ful_x_variant":[
+        "Tonnga"
+    ],
     "name:gag_x_preferred":[
         "Tonga"
     ],
@@ -256,6 +283,15 @@
     "name:gom_x_preferred":[
         "\u091f\u094b\u0902\u0917\u093e"
     ],
+    "name:gpe_x_preferred":[
+        "Tonga"
+    ],
+    "name:grc_x_preferred":[
+        "\u03a4\u03cc\u03b3\u03b3\u03b1"
+    ],
+    "name:grn_x_preferred":[
+        "T\u00f3nga"
+    ],
     "name:gsw_x_preferred":[
         "Tonga"
     ],
@@ -270,6 +306,9 @@
     ],
     "name:hau_x_preferred":[
         "Tanga"
+    ],
+    "name:hau_x_variant":[
+        "Tonga"
     ],
     "name:hbs_x_preferred":[
         "Tonga"
@@ -415,6 +454,9 @@
     "name:lit_x_variant":[
         "Tong\u0173"
     ],
+    "name:lld_x_preferred":[
+        "Tonga"
+    ],
     "name:lmo_x_preferred":[
         "Tonga"
     ],
@@ -439,6 +481,9 @@
     "name:mar_x_preferred":[
         "\u091f\u094b\u0902\u0917\u093e"
     ],
+    "name:mhr_x_preferred":[
+        "\u0422\u043e\u043d\u0433\u0430"
+    ],
     "name:mkd_x_preferred":[
         "\u0422\u043e\u043d\u0433\u0430"
     ],
@@ -448,11 +493,20 @@
     "name:mlg_x_preferred":[
         "Tong\u00e0"
     ],
+    "name:mlg_x_variant":[
+        "T\u00f4nga"
+    ],
     "name:mlt_x_preferred":[
         "Tonga"
     ],
+    "name:mni_x_preferred":[
+        "\uabc7\uabe3\uabe1\uabd2\uabe5"
+    ],
     "name:mon_x_preferred":[
         "\u0422\u043e\u043d\u0433\u0430"
+    ],
+    "name:mri_x_preferred":[
+        "Tonga"
     ],
     "name:mrj_x_preferred":[
         "\u0422\u043e\u043d\u0433\u0430"
@@ -483,6 +537,9 @@
     ],
     "name:nav_x_preferred":[
         "T\u02bc\u00f3nga"
+    ],
+    "name:nav_x_variant":[
+        "K\u02bc\u00e9daan\u00edinii Bik\u00e9yah"
     ],
     "name:nde_x_preferred":[
         "Thonga"
@@ -589,6 +646,9 @@
     "name:sgs_x_preferred":[
         "Tuonga"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1011\u103d\u1004\u103a\u1038\u1075\u1083\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0da7\u0ddc\u0d82\u0d9c\u0dcf"
     ],
@@ -604,8 +664,14 @@
     "name:sme_x_preferred":[
         "Tonga"
     ],
+    "name:smn_x_preferred":[
+        "Tonga"
+    ],
     "name:smo_x_preferred":[
         "Toga"
+    ],
+    "name:sms_x_preferred":[
+        "Tonga"
     ],
     "name:sna_x_preferred":[
         "Tonga"
@@ -672,6 +738,9 @@
     "name:tir_x_preferred":[
         "\u1276\u1295\u130b"
     ],
+    "name:tok_x_preferred":[
+        "ma Tona"
+    ],
     "name:ton_x_preferred":[
         "Tonga"
     ],
@@ -693,6 +762,9 @@
     "name:twi_x_preferred":[
         "Tonga"
     ],
+    "name:udm_x_preferred":[
+        "\u0422\u043e\u043d\u0433\u0430"
+    ],
     "name:uig_x_preferred":[
         "Ton\u2019ga"
     ],
@@ -712,6 +784,9 @@
         "\u0679\u0648\u0646\u06af\u0627"
     ],
     "name:uzb_x_preferred":[
+        "Tonga"
+    ],
+    "name:vec_x_preferred":[
         "Tonga"
     ],
     "name:vep_x_preferred":[
@@ -991,7 +1066,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1617827404,
+    "wof:lastmodified":1690874882,
     "wof:name":"Tonga",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/790/03/85679003.geojson
+++ b/data/856/790/03/85679003.geojson
@@ -29,29 +29,218 @@
     "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
+    "name:afr_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:arg_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:ast_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:bar_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:bre_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:cat_x_preferred":[
+        "Tongatapu"
+    ],
     "name:ceb_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:ces_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:cos_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:cym_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:dan_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:deu_x_preferred":[
         "Tongatapu"
     ],
     "name:eng_x_preferred":[
         "Tongatapu"
     ],
+    "name:epo_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:est_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:eus_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:fin_x_preferred":[
+        "Tongatapu"
+    ],
     "name:fra_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:frp_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:fur_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:gla_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:gle_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:glg_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:gsw_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:hrv_x_preferred":[
         "Tongatapu"
     ],
     "name:hun_x_preferred":[
         "Tongatapu"
     ],
+    "name:ido_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:ile_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:ina_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:ind_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:isl_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:ita_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c8\u30f3\u30ac\u30bf\u30d7\uff08\u5730\u533a\uff09"
+    ],
+    "name:kat_x_preferred":[
+        "\u10e2\u10dd\u10dc\u10d2\u10d0\u10e2\u10d0\u10de\u10e3\u10e1 \u10dd\u10da\u10e5\u10d8"
+    ],
+    "name:kon_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:lij_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:lim_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:ltz_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:min_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:mlg_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:msa_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:nap_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:nds_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:nld_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:nno_x_preferred":[
+        "Tongatapu"
+    ],
     "name:nob_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:nrm_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:oci_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:pcd_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:pms_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:pol_x_preferred":[
         "Tongatapu"
     ],
     "name:por_x_preferred":[
         "Tongatapu"
     ],
+    "name:roh_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:ron_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:scn_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:sco_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:slk_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:slv_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:spa_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:srd_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:swa_x_preferred":[
+        "Tongatapu"
+    ],
     "name:swe_x_preferred":[
         "Tongatapu"
     ],
+    "name:ukr_x_preferred":[
+        "\u0422\u043e\u043d\u0433\u0430\u0442\u0430\u043f\u0443"
+    ],
     "name:und_x_variant":[
         "Tongatapu Island Division"
+    ],
+    "name:vec_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:vie_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:vls_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:vol_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:wln_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:wol_x_preferred":[
+        "Tongatapu"
+    ],
+    "name:zul_x_preferred":[
+        "Tongatapu"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"TON",
@@ -171,7 +360,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1636495628,
+    "wof:lastmodified":1690874880,
     "wof:name":"Tongatapu",
     "wof:parent_id":85632455,
     "wof:placetype":"region",

--- a/data/856/790/11/85679011.geojson
+++ b/data/856/790/11/85679011.geojson
@@ -54,10 +54,19 @@
     "name:eng_x_preferred":[
         "Niuas"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u0632\u0627\u06cc\u0631 \u0646\u06cc\u0648\u0622"
+    ],
     "name:fin_x_preferred":[
         "Niuas"
     ],
     "name:fra_x_preferred":[
+        "Niuas"
+    ],
+    "name:fra_x_variant":[
+        "\u00eeles Niua"
+    ],
+    "name:frr_x_preferred":[
         "Niuas"
     ],
     "name:glg_x_preferred":[
@@ -80,6 +89,9 @@
     ],
     "name:ita_x_preferred":[
         "Niuas"
+    ],
+    "name:ita_x_variant":[
+        "Isole Niua"
     ],
     "name:jpn_x_preferred":[
         "\u30cb\u30a6\u30a2\u30b9\u8af8\u5cf6"
@@ -279,7 +291,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1636495628,
+    "wof:lastmodified":1690874880,
     "wof:name":"Niuas",
     "wof:parent_id":85632455,
     "wof:placetype":"region",

--- a/data/856/790/15/85679015.geojson
+++ b/data/856/790/15/85679015.geojson
@@ -41,6 +41,9 @@
     "name:cat_x_variant":[
         "Ha'apai"
     ],
+    "name:ceb_x_preferred":[
+        "Ha\u2018apai Group"
+    ],
     "name:dan_x_preferred":[
         "Ha\u02bbapai"
     ],
@@ -71,6 +74,9 @@
     "name:fra_x_variant":[
         "Ha\u2019apai",
         "Ha'apai"
+    ],
+    "name:frr_x_preferred":[
+        "Ha\u02bbapai"
     ],
     "name:glg_x_preferred":[
         "Ha'apai"
@@ -287,7 +293,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1636495629,
+    "wof:lastmodified":1690874881,
     "wof:name":"Ha'apai",
     "wof:parent_id":85632455,
     "wof:placetype":"region",

--- a/data/856/790/21/85679021.geojson
+++ b/data/856/790/21/85679021.geojson
@@ -39,6 +39,9 @@
     "name:deu_x_preferred":[
         "\u2019Eua"
     ],
+    "name:deu_x_variant":[
+        "\u02bbEua"
+    ],
     "name:eng_x_preferred":[
         "Eua"
     ],
@@ -202,7 +205,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1636495628,
+    "wof:lastmodified":1690874881,
     "wof:name":"Eua",
     "wof:parent_id":85632455,
     "wof:placetype":"region",

--- a/data/890/422/945/890422945.geojson
+++ b/data/890/422/945/890422945.geojson
@@ -22,6 +22,9 @@
     "name:ceb_x_preferred":[
         "Hihifo"
     ],
+    "name:deu_x_preferred":[
+        "Hihifo"
+    ],
     "name:eng_x_preferred":[
         "Hihifo"
     ],
@@ -42,6 +45,12 @@
     ],
     "name:rus_x_preferred":[
         "\u0425\u0438\u0445\u0438\u0444\u043e"
+    ],
+    "name:spa_x_preferred":[
+        "Hihifo"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e2e\u0e35\u0e2e\u0e35\u0e42\u0e1f"
     ],
     "name:zho_x_preferred":[
         "\u5e0c\u5e0c\u798f"
@@ -73,7 +82,7 @@
         }
     ],
     "wof:id":890422945,
-    "wof:lastmodified":1566581544,
+    "wof:lastmodified":1690874882,
     "wof:name":"Hihifo",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.