### PR TITLE
to concordances, placetype local, and more

### DIFF
--- a/data/856/324/55/85632455.geojson
+++ b/data/856/324/55/85632455.geojson
@@ -1035,6 +1035,7 @@
         "hasc:id":"TO",
         "icao:code":"A3",
         "ioc:id":"TGA",
+        "iso:code":"TO",
         "itu:id":"TON",
         "m49:code":"776",
         "marc:id":"to",
@@ -1048,6 +1049,7 @@
         "wk:page":"Tonga",
         "wmo:id":"TO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TO",
     "wof:country_alpha3":"TON",
     "wof:geom_alt":[
@@ -1070,7 +1072,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1694639510,
+    "wof:lastmodified":1695881164,
     "wof:name":"Tonga",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/790/03/85679003.geojson
+++ b/data/856/790/03/85679003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022586,
-    "geom:area_square_m":260405366.368412,
+    "geom:area_square_m":260405571.868572,
     "geom:bbox":"-176.219309,-22.3388,-175.050893,-21.062595",
     "geom:latitude":-21.182443,
     "geom:longitude":-175.213765,
@@ -337,13 +337,15 @@
         "gn:id":4032279,
         "gp:id":2347210,
         "hasc:id":"TO.TT",
+        "iso:code":"TO-04",
         "iso:id":"TO-04",
         "qs_pg:id":890104,
         "unlc:id":"TO-04",
         "wd:id":"Q10383165"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TO",
-    "wof:geomhash":"ef35e9113742034e6c00a34bd483344f",
+    "wof:geomhash":"c16ded0485a8758dca04ec178612fd6b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -360,7 +362,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1690874880,
+    "wof:lastmodified":1695884802,
     "wof:name":"Tongatapu",
     "wof:parent_id":85632455,
     "wof:placetype":"region",

--- a/data/856/790/07/85679007.geojson
+++ b/data/856/790/07/85679007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011241,
-    "geom:area_square_m":131706259.786271,
+    "geom:area_square_m":131706465.502605,
     "geom:bbox":"-174.664133,-18.817478,-173.914255,-18.566176",
     "geom:latitude":-18.637719,
     "geom:longitude":-174.04837,
@@ -270,13 +270,15 @@
         "gn:id":4032231,
         "gp:id":2347211,
         "hasc:id":"TO.VA",
+        "iso:code":"TO-05",
         "iso:id":"TO-05",
         "qs_pg:id":239517,
         "unlc:id":"TO-05",
         "wd:id":"Q859666"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TO",
-    "wof:geomhash":"ca9140ca8dd6a37e8c1d75aa3633e6fc",
+    "wof:geomhash":"0801c733e6f7cf13768ebd0c230511fa",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -293,7 +295,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1636495628,
+    "wof:lastmodified":1695884803,
     "wof:name":"Vava'u",
     "wof:parent_id":85632455,
     "wof:placetype":"region",

--- a/data/856/790/11/85679011.geojson
+++ b/data/856/790/11/85679011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004786,
-    "geom:area_square_m":56977393.126953,
+    "geom:area_square_m":56977732.200278,
     "geom:bbox":"-175.686269,-15.976739,-173.713531,-15.559503",
     "geom:latitude":-15.692069,
     "geom:longitude":-175.122029,
@@ -267,14 +267,16 @@
         "gn:id":7668055,
         "gp:id":-99,
         "hasc:id":"TO.NI",
+        "iso:code":"TO-03",
         "iso:id":"TO-03",
         "qs_pg:id":696679,
         "unlc:id":"TO-03",
         "wd:id":"Q1200954",
         "wk:page":"Niuas"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TO",
-    "wof:geomhash":"7cfb164b63d86f2f696374e1926783c6",
+    "wof:geomhash":"4325dd30b917f47be6bb3e1b3d79947c",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -291,7 +293,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1690874880,
+    "wof:lastmodified":1695884803,
     "wof:name":"Niuas",
     "wof:parent_id":85632455,
     "wof:placetype":"region",

--- a/data/856/790/15/85679015.geojson
+++ b/data/856/790/15/85679015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009119,
-    "geom:area_square_m":106114312.614084,
+    "geom:area_square_m":106114655.267609,
     "geom:bbox":"-175.100331,-20.267104,-174.244008,-19.592706",
     "geom:latitude":-19.768735,
     "geom:longitude":-174.680555,
@@ -270,13 +270,15 @@
         "gn:id":4032637,
         "gp:id":2347209,
         "hasc:id":"TO.HA",
+        "iso:code":"TO-02",
         "iso:id":"TO-02",
         "qs_pg:id":1135384,
         "unlc:id":"TO-02",
         "wd:id":"Q612098"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TO",
-    "wof:geomhash":"be31dd986049953f7092b7386f423c61",
+    "wof:geomhash":"48ce85afa0987ddbe38329667e55475b",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -293,7 +295,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1690874881,
+    "wof:lastmodified":1695884803,
     "wof:name":"Ha'apai",
     "wof:parent_id":85632455,
     "wof:placetype":"region",

--- a/data/856/790/21/85679021.geojson
+++ b/data/856/790/21/85679021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006857,
-    "geom:area_square_m":78952840.225586,
+    "geom:area_square_m":78952223.02547,
     "geom:bbox":"-174.983632,-21.454197,-174.908518,-21.284438",
     "geom:latitude":-21.374511,
     "geom:longitude":-174.937956,
@@ -183,12 +183,14 @@
         "gn:id":7668021,
         "gp:id":-99,
         "hasc:id":"TO.EU",
+        "iso:code":"TO-01",
         "iso:id":"TO-01",
         "unlc:id":"TO-01",
         "wd:id":"Q18472979"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TO",
-    "wof:geomhash":"e8861eb132364560796f6f43529a6f58",
+    "wof:geomhash":"dc8e95c0f75b18cefb3bdc2265771e35",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -205,7 +207,7 @@
         "ton",
         "eng"
     ],
-    "wof:lastmodified":1690874881,
+    "wof:lastmodified":1695884803,
     "wof:name":"Eua",
     "wof:parent_id":85632455,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.